### PR TITLE
在普通模式下删除和修改字符不会切换输入法，升级org.jetbrains.intellij

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.2.7"
+    id "org.jetbrains.intellij" version "0.2.17"
 }
 
 apply plugin: 'idea'

--- a/src/main/java/io/github/hadixlin/iss/KeepEnglishInNormalAndRestoreInInsertExtension.java
+++ b/src/main/java/io/github/hadixlin/iss/KeepEnglishInNormalAndRestoreInInsertExtension.java
@@ -26,11 +26,10 @@ public class KeepEnglishInNormalAndRestoreInInsertExtension implements VimExtens
     private static final Set<String> SWITCH_TO_LAST_INPUT_SOURCE_COMMAND_NAMES = ImmutableSet.of(
             "Vim Insert After Cursor", "Vim Insert After Line End", "Vim Insert Before Cursor",
             "Vim Insert Before First non-Blank", "Vim Insert Character Above Cursor",
-            "Vim Insert Character Below Cursor", "Vim Delete Inserted Text", "Vim Delete Previous Word",
+            "Vim Insert Character Below Cursor", 
             "Vim Enter", "Vim Insert at Line Start", "Vim Insert New Line Above",
             "Vim Insert New Line Below", "Vim Insert Previous Text", "Vim Insert Previous Text",
-            "Vim Insert Register", "Vim Toggle Insert/Replace", "Vim Change Line", "Vim Change Character",
-            "Vim Change Characters", "Vim Replace"
+            "Vim Insert Register" 
     );
 
     private boolean restoreInInsert = true;


### PR DESCRIPTION
1.在普通模式下，删除和修改字符后还是处于普通模式，在这里切换输入法没有任何意义。
2.升级org.jetbrains.intellij 到0.2.17，否则在编译的时候会出错。