### PR TITLE
feat: support UnicodeHexInput in macos

### DIFF
--- a/src/main/kotlin/io/github/hadixlin/iss/mac/MacInputMethodSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/mac/MacInputMethodSwitcher.kt
@@ -26,6 +26,10 @@ class MacInputMethodSwitcher : InputMethodSwitcher {
     override fun switchToEnglish() {
         val code = switchInputSource(ENGLISH_INPUT_SOURCE)
         if (code < 0) {
+            ENGLISH_INPUT_SOURCE = KEY_LAYOUT_ABC
+            code = switchInputSource(ENGLISH_INPUT_SOURCE)
+        }
+        if (code < 0) {
             ENGLISH_INPUT_SOURCE = KEY_LAYOUT_US
             switchInputSource(ENGLISH_INPUT_SOURCE)
         }
@@ -42,6 +46,7 @@ class MacInputMethodSwitcher : InputMethodSwitcher {
     companion object {
         private const val KEY_LAYOUT_US = "com.apple.keylayout.US"
         private const val KEY_LAYOUT_ABC = "com.apple.keylayout.ABC"
-        private var ENGLISH_INPUT_SOURCE = KEY_LAYOUT_ABC
+        private const val KEY_LAYOUT_UNICODEHEX = "com.apple.keylayout.UnicodeHexInput"
+        private var ENGLISH_INPUT_SOURCE = KEY_LAYOUT_UNICODEHEX
     }
 }


### PR DESCRIPTION


## 为什么要支持UnicodeHexInput
在macos下，一个历史性的坑是option键不能当作快捷键使用，因为他会输入一下奇奇怪怪的字符。但这不是系统的因素，而是输入法的原因，这是默认的英文输入法的行为。
这对普通用户当然没有什么问题，但对一个快捷键本就紧张的程序员来说却是要了老命了。长久以来解决这个问题的办法都是自制输入法。但好在10.14解决了这个问题，macos增加了一个新的输入法：`UnicodeHexInput`，该输入法允许将option当作快捷键使用。

## 使用场景
https://github.com/JetBrains/ideavim/blob/master/doc/emulated-plugins.md#multiple-cursors 
比如此插件，需要 option+n，在默认输入法下当然是不行的了，等同于此插件在mac下直接残废。而在UnicodeHexInput下，却可以完美工作。
具体见
https://youtrack.jetbrains.com/issue/VIM-1531
https://stackoverflow.com/questions/55202799/ideavim-multi-cursor-usage/55217839

## 为什么要优先使用此输入法
因为英文输入法是默认安装的，如果它不优先，则永远没有机会被切换了。