### PR TITLE
Allow setting of custom language package as default for OSX

### DIFF
--- a/src/main/kotlin/io/github/hadixlin/iss/InputMethodAutoSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/InputMethodAutoSwitcher.kt
@@ -37,6 +37,9 @@ object InputMethodAutoSwitcher {
     var enabled: Boolean = false
         private set
 
+    @Volatile
+    var normalModePackageName: String = "";
+
     private var executor: ThreadPoolExecutor? = null
 
     private val switcher = SystemInputMethodSwitcher()
@@ -44,7 +47,6 @@ object InputMethodAutoSwitcher {
     private var messageBusConnection: MessageBusConnection? = null
 
     private val exitInsertModeListener = object : CommandListener {
-
         override fun beforeCommandFinished(commandEvent: CommandEvent) {
             val commandName = commandEvent.commandName
             if (StringUtils.isBlank(commandName)) {
@@ -130,7 +132,7 @@ object InputMethodAutoSwitcher {
             }
             val state = CommandState.getInstance(editor)
             if (state.mode !in EDITING_MODE) {
-                executor?.execute { switcher.switchToEnglish() }
+                executor?.execute { switcher.switchToEnglish(normalModePackageName) }
             }
         }
     }

--- a/src/main/kotlin/io/github/hadixlin/iss/InputMethodSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/InputMethodSwitcher.kt
@@ -14,5 +14,5 @@ interface InputMethodSwitcher {
     fun restore()
 
     /** 切换输入法到英文 */
-    fun switchToEnglish()
+    fun switchToEnglish(packageName: String)
 }

--- a/src/main/kotlin/io/github/hadixlin/iss/KeepEnglishInNormalAndRestoreInInsertExtension.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/KeepEnglishInNormalAndRestoreInInsertExtension.kt
@@ -1,5 +1,6 @@
 package io.github.hadixlin.iss
 
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment
 import com.maddyhome.idea.vim.extension.VimExtension
 import com.maddyhome.idea.vim.option.OptionsManager
 import com.maddyhome.idea.vim.option.ToggleOption
@@ -19,6 +20,12 @@ class KeepEnglishInNormalAndRestoreInInsertExtension : VimExtension {
         val option =
             OptionsManager.getOption(KeepEnglishInNormalExtension.NAME) as ToggleOption?
         option?.set()
+
+        VimScriptGlobalEnvironment.getInstance().variables.let { vars ->
+            if (languagePackageName !in vars) vars[languagePackageName] = ""
+        }
+        InputMethodAutoSwitcher.normalModePackageName =
+            VimScriptGlobalEnvironment.getInstance().variables[languagePackageName].toString()
     }
 
     override fun dispose() {
@@ -27,6 +34,7 @@ class KeepEnglishInNormalAndRestoreInInsertExtension : VimExtension {
 
     companion object {
         const val NAME = "keep-english-in-normal-and-restore-in-insert"
+        private const val languagePackageName = "g:KeepEnglishInNormalAndRestore_package_name"
     }
 }
 

--- a/src/main/kotlin/io/github/hadixlin/iss/SystemInputMethodSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/SystemInputMethodSwitcher.kt
@@ -14,9 +14,10 @@ class SystemInputMethodSwitcher : InputMethodSwitcher {
         else -> throw IllegalArgumentException("Not Support Current System OS, Only Support Windows, MacOS and Linux(with fcitx)")
     }
 
-    override fun switchToEnglish() {
-        delegate.switchToEnglish()
+    override fun switchToEnglish(packageName: String) {
+        delegate.switchToEnglish(packageName)
     }
+
 
     override fun storeCurrentThenSwitchToEnglish() {
         delegate.storeCurrentThenSwitchToEnglish()

--- a/src/main/kotlin/io/github/hadixlin/iss/lin/LinFcitxRemoteSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/lin/LinFcitxRemoteSwitcher.kt
@@ -15,7 +15,7 @@ class LinFcitxRemoteSwitcher : InputMethodSwitcher {
         if (current == STATUS_INACTIVE) {
             return
         }
-        switchToEnglish()
+        switchToEnglish("")
     }
 
     override fun restore() {
@@ -25,7 +25,7 @@ class LinFcitxRemoteSwitcher : InputMethodSwitcher {
         }
     }
 
-    override fun switchToEnglish() {
+    override fun switchToEnglish(packageName: String) {
         execFcitxRemote(FCITX_INACTIVE)
     }
 

--- a/src/main/kotlin/io/github/hadixlin/iss/mac/MacInputMethodSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/mac/MacInputMethodSwitcher.kt
@@ -10,7 +10,6 @@ import org.apache.commons.lang.StringUtils.EMPTY
  * @date 2018-12-23
  */
 class MacInputMethodSwitcher : InputMethodSwitcher {
-
     @Volatile
     private var lastInputSource: String = EMPTY
 
@@ -20,10 +19,11 @@ class MacInputMethodSwitcher : InputMethodSwitcher {
         if (ENGLISH_INPUT_SOURCE == current) {
             return
         }
-        switchToEnglish()
+        switchToEnglish(ENGLISH_INPUT_SOURCE)
     }
 
-    override fun switchToEnglish() {
+    override fun switchToEnglish(packageName: String) {
+        ENGLISH_INPUT_SOURCE = packageName;
         if (ENGLISH_INPUT_SOURCE.isNotBlank()) {
             if (switchInputSource(ENGLISH_INPUT_SOURCE) < 0) {
                 // 系统英文输入法可能发生变更，导致无法切换到记录到英文输入法

--- a/src/main/kotlin/io/github/hadixlin/iss/win/WinInputMethodSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/win/WinInputMethodSwitcher.kt
@@ -36,7 +36,7 @@ class WinInputMethodSwitcher : InputMethodSwitcher {
         lastInputSource = -1
     }
 
-    override fun switchToEnglish() {
+    override fun switchToEnglish(packageName: String) {
         val hwnd = WinNative.INSTANCE.GetForegroundWindow()
         switchToInputSource(hwnd, KEY_LAYOUT_US)
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,11 +17,14 @@
         enable the feature with the commands below, input in normal mode:
       <ul>
         <li><code>:set keep-english-in-normal</code> enable auto-switch feature</li>
-        <li><code>:set keep-english-in-normal-and-restore-in-insert</code> restore input method when return insert mode</li>
+        <li><code>:set keep-english-in-normal-and-restore-in-insert</code> restore input method when return insert mode.</li>
         <li><code>:set nokeep-english-in-normal-and-restore-in-insert</code> keep auto-switch feature, but doesn't restore input method when return insert mode</li>
         <li><code>:set nokeep-english-in-normal</code> disable auto-switch feature</li>
       </ul>
       You can also add `set keep-english-in-normal[-and-restore-in-insert]` to the `~/.ideavimrc` file and restart IDE to enable the feature.
+
+      On OSX if you are using custom keyboard layout you can set the following flag before calling `keep-english-in-normal-and-restore-in-insert`:
+      <code>let g:KeepEnglishName_package_name_package_name = "org.sil.ukelele.keyboardlayout.abcnl.abcnl"</code>
 
       </p>
       <h3>Notice:</h3>


### PR DESCRIPTION
Hello,

since I'm using custom keyboard layout I needed a way to make this plugin work
with my current setup. 

Hope, you find this helpful.

Unfortunately I cannot test it under Linux and the other supported platform.

Probably it needs some refactoring. If so, feel free to point where and I will gladly do it.

Thank you for your time and effort for this great extension!