### PR TITLE
修复 当keep-english-in-normal配置顺序不标准时不能恢复到中文输入法

### DIFF
--- a/src/main/kotlin/io/github/hadixlin/iss/InputMethodAutoSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/InputMethodAutoSwitcher.kt
@@ -29,8 +29,20 @@ object InputMethodAutoSwitcher {
 		CommandState.Mode.REPLACE
 	)
 
+	var isRegisterVimInsertListener=false;
+
 	@Volatile
 	var restoreInInsert: Boolean = false
+		set(value) {
+			field = value
+			if(enabled){
+				if(value){
+					registerVimInsertListener();
+				}else{
+					unregisterVimInsertListener();
+				}
+			}
+		}
 
 	var contextAware: Boolean = false
 
@@ -116,11 +128,17 @@ object InputMethodAutoSwitcher {
 	}
 
 	private fun registerVimInsertListener() {
-		VimPlugin.getChange().addInsertListener(insertListener)
+		if(!isRegisterVimInsertListener){
+			isRegisterVimInsertListener=true;
+			VimPlugin.getChange().addInsertListener(insertListener)
+		}
 	}
 
 	private fun unregisterVimInsertListener() {
-		VimPlugin.getChange().removeInsertListener(insertListener)
+		if(isRegisterVimInsertListener){
+			isRegisterVimInsertListener=false;
+			VimPlugin.getChange().removeInsertListener(insertListener)
+		}
 	}
 
 	private fun registerFocusChangeListener() {

--- a/src/main/kotlin/io/github/hadixlin/iss/KeepEnglishInNormalAndRestoreInInsertExtension.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/KeepEnglishInNormalAndRestoreInInsertExtension.kt
@@ -17,10 +17,11 @@ class KeepEnglishInNormalAndRestoreInInsertExtension : VimExtension {
 	}
 
 	override fun init() {
-		InputMethodAutoSwitcher.restoreInInsert = true
 		InputMethodAutoSwitcher.contextAware =
 			VimPlugin.getVariableService().getGlobalVariableValue(CONTEXT_WARE)?.asBoolean() ?: true
 		VimPlugin.getOptionService().setOption(OptionService.Scope.GLOBAL, KeepEnglishInNormalExtension.NAME)
+
+		InputMethodAutoSwitcher.restoreInInsert = true
 	}
 
 	override fun dispose() {


### PR DESCRIPTION
原来在.ideavimrc文件中，必须按以下标准顺序配置才能恢复到中文输入法
1 set keep-english-in-normal-and-restore-in-insert 2 set keep-english-in-normal

现在修改成任意配置顺序都可以恢复到中文输入法