### PR TITLE
支持 Fcitx5-rime 使用 ASCII 模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,22 @@ ideavim.rc中还可以通过以下三个变量控制插件行为：
 
 ``` let context_aware=1进入insert模式时根据上下文判断是否恢复输入法，0禁用，1启用```
 
+Linux 下的 fcitx5-rime 可以通过显式申明 `IDEA_VIM_EXTENSION_USE_RIME_ASCII` 环境变量在 normal 模式使用 Rime 的 ASCII Mode。
+
+版本要求：
+  - `fcitx5 > 5.0.20`
+  - `fcitx5-rime > 5.0.8`
+
 ## 更新历史
+* 1.6.13
+
+  支持 Linux 下的 fcitx5-rime 使用 Rime ASCII 模式切换输入法。
+  需要显式申明 `IDEA_VIM_EXTENSION_USE_RIME_ASCII` 环境变量
+   
+  - fcitx5 和 fcitx5-rime 版本要求：
+    - `fcitx5 > 5.0.20`
+    - `fcitx5-rime > 5.0.8`
+
 * 1.6.12
 
   修正由于配置顺序导致无法恢复输入法的问题

--- a/src/main/kotlin/io/github/hadixlin/iss/SystemInputMethodSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/SystemInputMethodSwitcher.kt
@@ -2,24 +2,27 @@ package io.github.hadixlin.iss
 
 import com.maddyhome.idea.vim.VimPlugin
 import io.github.hadixlin.iss.lin.LinFcitxRemoteSwitcher
+import io.github.hadixlin.iss.lin.LinFcitx5RimeSwitcher
 import io.github.hadixlin.iss.lin.LinuxIbusSwitcher
 import io.github.hadixlin.iss.mac.MacInputMethodSwitcher
 import io.github.hadixlin.iss.win.WinInputMethodSwitcher
 import org.apache.commons.lang.SystemUtils
+import java.lang.NullPointerException
+import java.util.concurrent.TimeUnit
+import java.util.Scanner
 
 
 /** Created by hadix on 26/12/2018.  */
 class SystemInputMethodSwitcher
 	: InputMethodSwitcher {
-	private var delegate: InputMethodSwitcher
+	private val delegate: InputMethodSwitcher by lazy {
 
-	init {
 		//获取输入法设置的环境变量
 		//当前系统环境变量判断
 		val variableService = VimPlugin.getVariableService()
 		val english = variableService.getGlobalVariableValue(INPUT_SOURCE_IN_NORMAL)
 		val nonEnglish = variableService.getGlobalVariableValue(INPUT_SOURCE_IN_INSERT)
-		delegate = when {
+		return@lazy when {
 			SystemUtils.IS_OS_WINDOWS -> {
 				WinInputMethodSwitcher(
 					english?.toVimNumber()?.value?.toLong(), nonEnglish?.toVimNumber()?.value?.toLong()
@@ -38,9 +41,18 @@ class SystemInputMethodSwitcher
 				//获取输入法设置的环境变量
 				val qtInputMethod = System.getenv(QT_INPUT_METHOD)
 				val gtkInputMethod = System.getenv(GTK_INPUT_METHOD)
+				val useRimeASCII = try {
+					System.getenv(IDEA_VIM_EXTENSION_USE_RIME_ASCII)
+				} catch (e: NullPointerException){
+					""
+				}
 				//当前系统环境变量判断
 				if (isFcitx(qtInputMethod, gtkInputMethod)) {
-					LinFcitxRemoteSwitcher()
+					if (useRimeASCII.isNotEmpty() && canUseRimeAscii()){
+						LinFcitx5RimeSwitcher()
+					}else{
+						LinFcitxRemoteSwitcher()
+					}
 				} else if (isIbus(qtInputMethod, gtkInputMethod)) {
 					LinuxIbusSwitcher()
 				} else {
@@ -73,11 +85,32 @@ class SystemInputMethodSwitcher
 		private const val INPUT_METHOD_IBUS = "ibus"
 		private const val QT_INPUT_METHOD = "QT_IM_MODULE"
 		private const val GTK_INPUT_METHOD = "GTK_IM_MODULE"
+		private const val IDEA_VIM_EXTENSION_USE_RIME_ASCII = "IDEA_VIM_EXTENSION_USE_RIME_ASCII"
+
 		fun isFcitx(qtInputMethod: String?, gtkInputMethod: String?): Boolean {
 			return qtInputMethod == INPUT_METHOD_FCITX
 					|| gtkInputMethod == INPUT_METHOD_FCITX
 					|| qtInputMethod == INPUT_METHOD_FCITX5
 					|| gtkInputMethod == INPUT_METHOD_FCITX5
+		}
+
+		fun canUseRimeAscii(): Boolean{
+			val cmd = arrayOf("busctl", "--user",  "call", "org.fcitx.Fcitx5", "/controller",
+				"org.fcitx.Fcitx.Controller1","CurrentInputMethod")
+			val proc = Runtime.getRuntime().exec(cmd)
+			proc.waitFor(3, TimeUnit.SECONDS)
+			return Scanner(proc.inputStream).use {
+				if (it.hasNext()) {
+					val firstToken = it.next()
+					val sb = StringBuffer()
+					while(it.hasNext()){
+						sb.append(it.next())
+					}
+					firstToken == "s" && sb.contains("rime")
+				} else {
+					false
+				}
+			}
 		}
 
 		fun isIbus(qtInputMethod: String?, gtkInputMethod: String?): Boolean =

--- a/src/main/kotlin/io/github/hadixlin/iss/lin/LinFcitx5RimeSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/lin/LinFcitx5RimeSwitcher.kt
@@ -1,0 +1,73 @@
+package io.github.hadixlin.iss.lin
+
+import io.github.hadixlin.iss.InputMethodSwitcher
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class LinFcitx5RimeSwitcher : InputMethodSwitcher {
+
+    private var lastStatus = STATUS_ASCII
+
+	override fun storeCurrentThenSwitchToEnglish() {
+        val currentStatus = getFcitxRimeStatus()
+        lastStatus = currentStatus
+		if (currentStatus == STATUS_IME){
+			switchToEnglish()
+		}
+	}
+
+	override fun restore() {
+        if (lastStatus != STATUS_ASCII){
+            execFcitxRime(FCITX_RIME_IME)
+        }
+	}
+
+	override fun switchToEnglish() {
+		execFcitxRime(FCITX_RIME_ASCII)
+	}
+
+	companion object {
+		private const val BUS_TYPE = "b"
+		private const val STATUS_ASCII = "true"
+		private const val STATUS_IME = "false"
+
+		private val FCITX_RIME_IME: Array<String>
+		private val FCITX_RIME_ASCII: Array<String>
+		private val FCITX_RIME_STATUS: Array<String>
+
+		init {
+			val busctlCall: Array<String>
+
+			busctlCall = arrayOf("busctl",
+             "call", "--user", "org.fcitx.Fcitx5",
+             "/rime", "org.fcitx.Fcitx.Rime1")
+
+			FCITX_RIME_IME = busctlCall.plus(arrayOf("SetAsciiMode", BUS_TYPE, STATUS_IME)) // active input method
+			FCITX_RIME_ASCII = busctlCall.plus(arrayOf("SetAsciiMode", BUS_TYPE, STATUS_ASCII)) //inactivate input method
+			FCITX_RIME_STATUS = busctlCall.plus(arrayOf("IsAsciiMode")) //get fcitx status
+		}
+
+		private fun execFcitxRime(cmd: Array<String>): Process {
+			val proc = Runtime.getRuntime().exec(cmd)
+			proc.waitFor(3, TimeUnit.SECONDS)
+			return proc
+		}
+
+		private fun getFcitxRimeStatus(): String {
+			val proc = execFcitxRime(FCITX_RIME_STATUS)
+			return Scanner(proc.inputStream).use {
+				if (it.hasNext()) {
+					val firstToken = it.next()
+                    if (firstToken == BUS_TYPE && it.hasNextBoolean()){
+                        "${it.nextBoolean()}"
+                    }else {
+                        STATUS_ASCII
+                    }
+				} else {
+					STATUS_ASCII
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
根据 [fcitx5 提供的方法](https://github.com/fcitx/fcitx5/discussions/624) 以及 [fcitx5-rime 提供的方法](https://github.com/fcitx/fcitx5-rime/issues/30)，支持了使用 Rime 的 ASCII 模式。

需要显式的申明 `IDEA_VIM_EXTENSION_USE_RIME_ASCII` 环境变量来启用，可以在参考 [使用 Desktop 配置环境变量使用](https://wiki.archlinux.org/title/desktop_entries#Modify_environment_variables)。