### PR TITLE
fix: 修复当安装中文语言包时, 输入法切换不生效的问题

### DIFF
--- a/src/main/kotlin/io/github/hadixlin/iss/InputMethodAutoSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/InputMethodAutoSwitcher.kt
@@ -22,7 +22,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 object InputMethodAutoSwitcher {
-    private val VIM_INSERT_EXIT_MODE_ACTION = arrayOf("Escape", "VimInsertExitModeAction")
+    private val VIM_INSERT_EXIT_MODE_ACTION = arrayOf("Escape", "Esc", "VimInsertExitModeAction")
 
     private val EDITING_MODES = EnumSet.of(
         CommandState.Mode.INSERT,


### PR DESCRIPTION
经调试发现，当安装中文语言包后，command 会从 `Escape` 变成 `Esc`

![Snipaste_2024-02-08_05-44-34](https://github.com/hadix-lin/ideavim_extension/assets/20502666/a4a42e5c-9485-43f5-af90-03c11f9acad4)
![Snipaste_2024-02-08_05-46-13](https://github.com/hadix-lin/ideavim_extension/assets/20502666/ac9e8796-acf2-4a1e-8c9a-ccce9ec7f187)
