### PR TITLE
Fix incorrect input method restore when cursor is at the end of the file

### DIFF
--- a/src/main/kotlin/io/github/hadixlin/iss/InputMethodAutoSwitcher.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/InputMethodAutoSwitcher.kt
@@ -77,7 +77,7 @@ object InputMethodAutoSwitcher {
                 val pos = editor.caretModel.primaryCaret.offset
                 val chars = editor.document.charsSequence.subSequence(
                     max(pos - 1, 0),
-                    min(pos + 1, editor.document.textLength - 1)
+                    min(pos + 1, editor.document.textLength)
                 )
                 if (chars.any { CharUtils.isAsciiPrintable(it) }) {
                     return


### PR DESCRIPTION
Fixed:
- [x] When the cursor is at the end of the file, the surrounding character sequence ends up empty and the ASCII condition never matches, so the alternative input method is always restored, even when the previous (and final) character is ASCII.