### PR TITLE
Fix missing resource bundle property reference

### DIFF
--- a/src/main/kotlin/io/github/hadixlin/iss/KeepEnglishInNormalAndRestoreInInsertExtension.kt
+++ b/src/main/kotlin/io/github/hadixlin/iss/KeepEnglishInNormalAndRestoreInInsertExtension.kt
@@ -2,7 +2,7 @@ package io.github.hadixlin.iss
 
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.setToggleOption
-import com.maddyhome.idea.vim.ex.exExceptionMessage
+import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.extension.VimExtension
 import com.maddyhome.idea.vim.options.OptionAccessScope
 import com.maddyhome.idea.vim.options.ToggleOption
@@ -25,7 +25,7 @@ class KeepEnglishInNormalAndRestoreInInsertExtension : VimExtension {
         val optionGroup = VimPlugin.getOptionGroup()
         val option =
             (optionGroup.getOption(KeepEnglishInNormalExtension.NAME)
-                ?: throw exExceptionMessage("option not found")) as ToggleOption
+                ?: throw ExException("Option '${KeepEnglishInNormalExtension.NAME}' not found")) as ToggleOption
         optionGroup.setToggleOption(option, OptionAccessScope.GLOBAL(null))
     }
 


### PR DESCRIPTION
## Summary
- Replace `exExceptionMessage("option not found")` with `ExException` directly
- The `exExceptionMessage` function expects a resource bundle key from `IdeaVimEngineBundle`, but "option not found" is not a valid key, leading to `MissingResourceException` at runtime